### PR TITLE
Fix parsing of integers with trailing zeroes

### DIFF
--- a/src/main/java/recipe/lang/types/Integer.java
+++ b/src/main/java/recipe/lang/types/Integer.java
@@ -32,7 +32,7 @@ public class Integer extends Real {
     @Override
     public java.lang.Number interpret(String value) throws MismatchingTypeException {
         try{
-            return java.lang.Integer.parseInt(value.replaceAll(".0+$", ""));
+            return java.lang.Integer.parseInt(value.replaceAll("\\.0+$", ""));
         } catch (Exception e) {
             throw new MismatchingTypeException(value + " is not of type " + name());
         }


### PR DESCRIPTION
Integers with trailing zeroes get their last non-zero digit, as well as the trailing zeroes, removed during parsing. Examples of such integers are 10, 20, 30, 100, 1000, and so on.

Fix this by escaping the '.' in the regular expression, making it match a literal '.', rather than any single character.