### PR TITLE
Add missing parenthesis to next() variable assignment in smv code

### DIFF
--- a/src/main/java/recipe/analysis/ToNuXmv.java
+++ b/src/main/java/recipe/analysis/ToNuXmv.java
@@ -579,13 +579,13 @@ public class ToNuXmv {
                                         // else relabel variables appropriately
                                         for (Map.Entry<String, Expression> entry : receiveProcess.getUpdate().entrySet()) {
                                             receiveTransEffects
-                                                    .add("next(" + receiveName + "-" + entry.getKey() + ") = "
+                                                    .add("next(" + receiveName + "-" + entry.getKey() + ") = ("
                                                             + entry.getValue().relabel(v ->
                                                             sendingProcess.getMessage().containsKey(((TypedVariable) v).getName())
                                                                     ? relabelledMessage.get(((TypedVariable) v).getName())
                                                                     : (system.getMessageStructure().containsKey(((TypedVariable) v).getName())
                                                                     ? stopHelper.apply((TypedVariable) v)
-                                                                    : ((TypedVariable) v).sameTypeWithName(receiveName + "-" + v))));
+                                                                    : ((TypedVariable) v).sameTypeWithName(receiveName + "-" + v))) + ")");
                                         }
 
                                         //stop considering this transition if update uses a message variable


### PR DESCRIPTION
The right-hand side of assignments to the next state of an smv variable must be parenthesized to avoid operator precedence issues.

For example, an assignment like [equal := a == b] where equal is a boolean and a and b are integers, will cause a typing error in nuxmv due to assigning an integer value to a boolean variable, due to equality being left-associative.